### PR TITLE
Disable auto-commit for JDBC connections

### DIFF
--- a/src/main/java/com/github/mjdbc/DbConnection.java
+++ b/src/main/java/com/github/mjdbc/DbConnection.java
@@ -42,6 +42,7 @@ public class DbConnection {
         if (sqlConnection == null) {
             try {
                 sqlConnection = db.dataSource.getConnection();
+                sqlConnection.setAutoCommit(false);
             } catch (SQLException e) {
                 throw new RuntimeException("Failed to get connection from DataSource!", e);
             }


### PR DESCRIPTION
First of all thanks for MJDBC, it very much looks like what I've been looking for! I'm just evaluating if the library fits my use cases but immediately stumbled on an issue with my Postgres setup:

## Problem description

By default, Postgres JDBC connections are set to auto-commit. This causes DbImpl::executeImpl to abort with an error

     Exception in thread "main" java.lang.RuntimeException: org.postgresql.util.PSQLException: Cannot rollback when autoCommit is enabled.
	at com.github.mjdbc.DbImpl.executeImpl(DbImpl.java:152)
	at com.github.mjdbc.DbImpl.execute(DbImpl.java:87)
	at com.github.mjdbc.SqlProxy.invoke(SqlProxy.java:39)
	
    Caused by: org.postgresql.util.PSQLException: Cannot rollback when autoCommit is enabled.
	at org.postgresql.jdbc.PgConnection.rollback(PgConnection.java:776)
	at com.zaxxer.hikari.pool.ProxyConnection.rollback(ProxyConnection.java:371)
	at com.zaxxer.hikari.pool.HikariProxyConnection.rollback(HikariProxyConnection.java)
	at com.github.mjdbc.DbConnection.rollback(DbConnection.java:62)
	at com.github.mjdbc.DbImpl.executeImpl(DbImpl.java:134)

The error is cascaded from [here](https://github.com/mjdbc/mjdbc/blob/master/src/main/java/com/github/mjdbc/DbImpl.java#L129) where `DbImpl::executeImpl` attempts to commit  and fails with the error returned by the Postgres DB server `25P01 : no_active_sql_transaction`

## Proposed solution

This patch disables auto-commit for all opened connections, which is the least intrusive to the MJDBC library.

## Alternative solution

I'm just going through the source of your library, but would be happy for your feedback on an alternative solution:

- Wouldn't any top-level executed SqlProxy method benefit from one less round-trip if DbImpl does not attempt to commit if the underlying sqlConnection `getAutoCommit()` returns true? As I understand, SqlProxies are meant always to execute just one SQL statement (except for batch updates).
- E.g. could the logic be: iff the executed `op` is coming from a SQLProxy *and* it's a top-level connection *and* it's not a batch command, then do not disable auto-commit, and do not attempt to commit the underlying SQL connection if it is set to auto-commit. In my project this would cover most probably 99% of all cases.

Thanks again for the library!
