### PR TITLE
Fix typo in Javadoc of DbPreparedStatement.

### DIFF
--- a/src/main/java/com/github/mjdbc/DbPreparedStatement.java
+++ b/src/main/java/com/github/mjdbc/DbPreparedStatement.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
  * Wrapper over ${PreparedStatement} with named parameters, results mapping ({@link DbMapper})
  * and bean binding ({@link @{@link BindBean}}) support.
  * <p>
- * Provides full access to underlying ${PreparedStatement} and ads useful utility methods.
+ * Provides full access to underlying ${PreparedStatement} and adds useful utility methods.
  * <p>
  * DbPreparedStatement is automatically closed on transaction commit/rollback.
  */


### PR DESCRIPTION
Just fixing typos while going through the source code.